### PR TITLE
Use URL helpers in path configuration

### DIFF
--- a/app/controllers/turbo/android/path_configurations_controller.rb
+++ b/app/controllers/turbo/android/path_configurations_controller.rb
@@ -29,7 +29,7 @@ module Turbo
               }
             },
             {
-              patterns: ["^$", "^/$"],
+              patterns: ["^$", "^#{root_path}$"],
               properties: {
                 uri: "turbo://fragment/web/home",
                 presentation: "replace_root"
@@ -44,7 +44,7 @@ module Turbo
               }
             },
             {
-              patterns: ["/users/sign_in"],
+              patterns: [new_user_session_path],
               properties: {
                 uri: "turbo://fragment/users/sign_in",
                 context: "modal"


### PR DESCRIPTION
We lost quite some time figuring out https://github.com/jumpstart-pro/jumpstart-pro-android/issues/227, so maybe this could spare someone else some troubleshooting time. We were using `patterns: ["/#{new_user_session_path}$"]` instead of `patterns: ["#{new_user_session_path}$"]` (we need the helper instead of hard-coding to localize URLs).