### PR TITLE
Fix icon convention for tab navigation

### DIFF
--- a/app/assets/images/icons/compose.svg
+++ b/app/assets/images/icons/compose.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2 4v14h14v-6l2-2v10H0V2h10L8 4H2zm10.3-.3l4 4L8 16H4v-4l8.3-8.3zm1.4-1.4L16 0l4 4-2.3 2.3-4-4z"/></svg>

--- a/app/assets/images/icons/home.svg
+++ b/app/assets/images/icons/home.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M8 20H3V10H0L10 0l10 10h-3v10h-5v-6H8v6z"/></svg>

--- a/app/controllers/turbo/android/path_configurations_controller.rb
+++ b/app/controllers/turbo/android/path_configurations_controller.rb
@@ -9,12 +9,12 @@ module Turbo
               {
                 title: "Home",
                 path: root_path,
-                image_url: svg_icon_path("home")
+                icon: "home"
               },
               {
                 title: "Posts",
                 path: posts_path,
-                image_url: svg_icon_path("compose")
+                icon: "announcement"
               }
             ].to_json
           },
@@ -53,14 +53,6 @@ module Turbo
           ]
         }
       end
-
-      private 
-
-        # Provide the name of the icon
-      def svg_icon_path(icon)
-        ActionController::Base.helpers.asset_path("icons/#{icon}.svg")
-      end
-
     end
   end
 end


### PR DESCRIPTION
As far as I understand navigation icons are no longer based on a server provided icon path. They’re now based on an icon name.     
This small PR will change the provided navigation icons from a path to a fixed icon name.     


Note:
I choose the "announcement" icon for Posts, because in the JumpstartPro Android App are following Icons out of the box provided: "home", "announcement" and "notifications".    
Thought "announcement" would make the most sense.
