### PR TITLE
Skip csrv token verification on auth controller.

### DIFF
--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -1,6 +1,8 @@
 module API
   module V1
     class AuthsController < ApplicationController
+      skip_before_action :verify_authenticity_token, only: [:destroy]
+
       def destroy
         current_user.notification_tokens
           .find_by(token: params[:notification_token])&.destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
-      resource :auth, only: [:create, :destroy]
+      resource :auth, only: [:destroy]
       resources :notification_tokens, only: :create
     end
   end


### PR DESCRIPTION
When testing with latest jumpstart-ios, I noticed the "Sign out" was erroring complaining about CSRF token.
Since this call is made natively as an API call, the AuthsController#destroy can safely skip this check.

Also, cleaned up the routes.rb by removing `:create` on auth as this doesn't exist. We rely fully on the Webview for Sign-in